### PR TITLE
Pruning requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-versioneer
 wheel
 bertopic
 pytest


### PR DESCRIPTION
There's a few deps in requirements.txt that are likely unnecessary. The versioneer package is only required for initial setup; versioneer files are generated into the repo.

Is setuptools required for a specific reason? Setuptools is almost always already present in a base environment, otherwise pip wouldn't work with sdists. The `bs4` and `beautifulsoup4` deps look redundant. pytest should be moved to a seperate `dev` optional requirements

- [x] remove versioneer
- [ ] remove setuptools?
- [ ] remove redundant `bs4`
- [ ] move pytest
