### PR TITLE
Split workflows by trigger to restrict when deploys occur

### DIFF
--- a/.github/workflows/berteley-main.yml
+++ b/.github/workflows/berteley-main.yml
@@ -1,0 +1,86 @@
+name: BERTeley CI
+
+# triggers on push
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.9' ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install -e .[tests]
+
+      - name: Run tests
+        run: pytest tests --cov=./ --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/reports/
+          env_vars: OS, PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          name: codecov-umbrella
+          path_to_write_report: ./coverage/codecov_report.txt
+          verbose: true
+
+  # Determine if this run is triggered by a push to main WITH a tagged commit
+  on-tag-check:
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      on_tag: ${{ steps.contains_tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # Determine what tag is associated with this push's HEAD
+      - name: Find Tag
+        id: tagger
+        uses: jimschubert/query-tag-action@v1
+  deploy:
+    needs: on-tag-check
+    # Only run deploy if tag does not contain a '-' (meaning no additional commits since last tag)
+    if: ${{ !contains(needs.on-tag-check.outputs.on_tag, '-' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Setup deploy
+        run: |
+          pip install --upgrade setuptools wheel twine
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
+
+      - name: Github Release
+        uses: fnkr/github-action-ghr@v1
+        env:
+          GHR_COMPRESS: xz
+          GHR_PATH: build/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/berteley-pr.yml
+++ b/.github/workflows/berteley-pr.yml
@@ -1,0 +1,40 @@
+name: BERTeley CD
+
+# triggers on PR to main
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.9' ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install -e .[tests]
+
+      - name: Run tests
+        run: pytest tests --cov=./ --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/reports/
+          env_vars: OS, PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          name: codecov-umbrella
+          path_to_write_report: ./coverage/codecov_report.txt
+          verbose: true

--- a/.github/workflows/berteley-tags.yml
+++ b/.github/workflows/berteley-tags.yml
@@ -1,12 +1,10 @@
 name: BERTeley CI
 
+# triggers on pushed tag
 on:
   push:
-    branches: [ main ]
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches: [ main ]
 
 jobs:
   test:
@@ -25,7 +23,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
           pip install -e .[tests]
 
       - name: Run tests
@@ -43,9 +40,27 @@ jobs:
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
 
-  deploy:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref == 'refs/heads/main'
+  # Determine if this run is triggered by a push to main
+  on-main-and-tagged-check:
     needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      on_main: ${{ steps.contains_tag.outputs.retval }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # Determine if trigger ref is in main
+      - uses: rickstaa/action-contains-tag@v1
+        id: contains_tag
+        with:
+          reference: "main"
+          tag: "${{ github.ref }}"
+
+  deploy:
+    needs: on-main-and-tagged-check
+    # Only run deploy if tag in main branch
+    if: ${{ needs.on-main-and-tagged-check.outputs.on_main == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR address a problem with the current workflow structure: tags pushed to PRs trigger deployment before merge. This issue can be avoided by not tagging branches other than `main`.

This proposed PR is complex in structure, has significant code duplication, and needs extensive testing. I'm marking it as a draft and leaving it here for future work. 

TODO:
- [ ] Reduce code duplication via [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
- [ ] Test pr workflow
- [ ] Test main workflow w/wo tag
- [ ] Test tags workflow w/wo main