### PR TITLE
Revert to not checking branch before deploy

### DIFF
--- a/.github/workflows/berteley-CI.yml
+++ b/.github/workflows/berteley-CI.yml
@@ -44,7 +44,7 @@ jobs:
           verbose: true
 
   deploy:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This reverts f01b44efc3d2f8a20cbe65b8307ce8233ba2626b

The above commit is problematic because `github.ref` can never be both `refs/tags/*` and `refs/heads/main`. The only issue with the previous behavior is that pushed tags will deploy even if they are only in a PR (before merging to master). This is non-ideal, but workable if you are aware of the behavior.

I advise that we be careful to only apply tags to the main branch directly to avoid this edge case.

An alternative workflow structure is proposed in https://github.com/lbl-camera/berteley/pull/27, however extensive testing is likely required. I recommend to postpone reviewing https://github.com/lbl-camera/berteley/pull/27 to post-publication.